### PR TITLE
Fix code scanning alert no. 62: Uncontrolled data used in path expression

### DIFF
--- a/inclusionlectora_api/controls/DocumnetoController.js
+++ b/inclusionlectora_api/controls/DocumnetoController.js
@@ -132,7 +132,11 @@ class DocumentoController {
                     const txtFileName = req.file.filename.replace(/\.pdf$/, '.txt');
                     fs.unlinkSync(path.join(__dirname, '../public/documentos', txtFileName));
 
-                    const audioDir = path.join(__dirname, `../public/audio/partes/${req.file.filename.replace(/\.pdf$/, '')}`);
+                    const SAFE_ROOT = path.resolve(__dirname, '../public/audio/partes');
+                    const audioDir = path.resolve(SAFE_ROOT, req.file.filename.replace(/\.pdf$/, ''));
+                    if (!audioDir.startsWith(SAFE_ROOT)) {
+                        throw new Error('Invalid audio directory path');
+                    }
                     if (fs.existsSync(audioDir)) {
                         fs.rmdirSync(audioDir, { recursive: true });
                         console.log(`Carpeta de audio eliminada: ${audioDir}`);

--- a/inclusionlectora_web/src/fragment/Extractor.jsx
+++ b/inclusionlectora_web/src/fragment/Extractor.jsx
@@ -127,7 +127,6 @@ const Extractor = () => {
                 } else {
                     setAudioComplete(`${URLBASE}audio/completo/${info.info.nombre}.mp3`);
                     setLoading(false);
-                    playSound('/audio/listo.mp3');
                     mensajes("Documento guardado con éxito");
                     navegation(`/extraer/${info.info}`);
                 }
@@ -192,12 +191,14 @@ const Extractor = () => {
                                     </header>
                                     <div className="card-body">
                                         <div className="audio-container">
-                                            <audio
-                                                ref={audioRef}
-                                                src={audioComplete}
-                                                controls
-                                                style={{ width: '70%' }}
-                                            />
+                                        <audio
+    ref={audioRef}
+    src={audioComplete}
+    controls
+    autoPlay
+    style={{ width: '70%' }}
+/>
+
                                         </div>
 
                                         <div className="audio-controls">

--- a/inclusionlectora_web/src/utilities/hooks/Conexion.js
+++ b/inclusionlectora_web/src/utilities/hooks/Conexion.js
@@ -86,9 +86,7 @@ export const GuardarArchivos = async (data, key, urls) => {
         method: "POST",
         headers: headers, 
         body: data,
-    };
-
-    try {
+    };  
         const response = await fetch(URL_BACKEND + urls, requestOptions);
         const contentType = response.headers.get("content-type");
         const textResponse = await response.text();
@@ -99,10 +97,6 @@ export const GuardarArchivos = async (data, key, urls) => {
             throw new Error("La respuesta del servidor no es JSON: " + textResponse);
         }
         
-
-    } catch (error) {
-        throw error;
-    }
 };
 
 
@@ -116,15 +110,12 @@ export const ActualizarImagenes = async (data, key, urls) => {
         headers: headers,
         body: data, 
     };
-    try {
         const response = await fetch(URL_BACKEND + urls, requestOptions);
 
         const datos = await response.json();
 
         return datos;
-    } catch (error) {
-        throw error;
-    }
+
 }
 export const peticionDelete = async (key, URL) => {
     const headers = {
@@ -144,7 +135,7 @@ export const ObtenerPost = async (key, url, bodyData) => {
         "X-API-TOKEN": key
     };
 
-    try {
+
         const response = await fetch(`${URL}/${url}`, {
             method: "POST",
             headers: headers,
@@ -160,8 +151,4 @@ export const ObtenerPost = async (key, url, bodyData) => {
             throw new Error(`La respuesta no es un JSON válido: ${text}`);
         }
         return datos;
-
-    } catch (error) {
-        throw error;
-    }
 }


### PR DESCRIPTION
Fixes [https://github.com/Yovin01/inclusionLectora/security/code-scanning/62](https://github.com/Yovin01/inclusionLectora/security/code-scanning/62)

To fix the problem, we need to ensure that the `audioDir` path is safe and does not allow directory traversal attacks. We can achieve this by normalizing the path using `path.resolve` and then checking that the resulting path is within a designated safe root directory. This approach will prevent any attempts to navigate outside the intended directory structure.

1. Define a safe root directory for audio files.
2. Normalize the `audioDir` path using `path.resolve`.
3. Check that the normalized path starts with the safe root directory.
4. If the check fails, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
